### PR TITLE
fix the buy link in the `RecommendationFeedViewController`

### DIFF
--- a/WiseBuy/Models/Post.h
+++ b/WiseBuy/Models/Post.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) NSString *itemName;
 @property (nonatomic, strong) NSString *sellerName;
 @property (nonatomic, strong) NSString *price;
-@property (nonatomic, strong) NSString *itemLink;
+@property (nonatomic, strong) NSString *link;
 
 @end
 

--- a/WiseBuy/Models/Post.m
+++ b/WiseBuy/Models/Post.m
@@ -14,7 +14,7 @@
 @dynamic itemName;
 @dynamic sellerName;
 @dynamic price;
-@dynamic itemLink;
+@dynamic link;
 
 + (nonnull NSString *)parseClassName {
     return @"Post";

--- a/WiseBuy/View Controllers/RecommendationFeedViewController.m
+++ b/WiseBuy/View Controllers/RecommendationFeedViewController.m
@@ -66,7 +66,6 @@ static NSString *const kConnectionSegue = @"connectionSegue";
         [query includeKey:@"first_name"];
         [query includeKey:@"last_name"];
         [query includeKey:@"image"];
-
         [query whereKey:@"objectId" equalTo:post.user.objectId];
         NSArray *user = query.findObjects;
 
@@ -85,10 +84,10 @@ static NSString *const kConnectionSegue = @"connectionSegue";
             cell.itemNameLabel.text = post.itemName;
             cell.priceLabel.text = post.price;
             cell.sellerLabel.text = post.sellerName;
-            cell.linkLabel.text = @"amazon.com"; // TODO: fix this later
+            cell.linkLabel.text = post.link;
             
             NSMutableAttributedString *str = [[NSMutableAttributedString alloc] initWithString:@"Buy Link"];
-            [str addAttribute: NSLinkAttributeName value: post.itemLink range: NSMakeRange(0, str.length)];
+            [str addAttribute: NSLinkAttributeName value: post.link range: NSMakeRange(0, str.length)];
             cell.linkLabel.attributedText = str;
             
         });


### PR DESCRIPTION
## Description

Fix the `linkLabel` in the `RecommendationFeedViewController` by changing the Post's `itemLink` attribute to `link` so that it matches the name on the Parse database

## Milestones
This is part of the user story 'User can see a feed of recommended deals'

## Test Plan

1. Run the app
2. Go to the Feed tab
3. You could now see the actual link of the deal rather than the hard-coded link like before