### PR TITLE
Add `UIAlertController` in the `ComposeViewController` to notify users when post can not be saved successfully

### DIFF
--- a/WiseBuy/Managers/AlertManager.h
+++ b/WiseBuy/Managers/AlertManager.h
@@ -29,7 +29,7 @@ typedef NS_ENUM(NSInteger, dealErrorType) {
 + (void)dealsNotFoundAlert:(UIViewController *)vc errorType:(dealErrorType)error;
 + (void)cannotOpenLink:(UIViewController *)vc;
 + (void)cannotSaveDeal:(UIViewController *)vc;
-
++ (void)cannotPostDeal:(UIViewController *)vc;
 
 @end
 

--- a/WiseBuy/Managers/AlertManager.m
+++ b/WiseBuy/Managers/AlertManager.m
@@ -122,4 +122,15 @@
     [vc presentViewController:alert animated:YES completion:nil];
 }
 
++ (void)cannotPostDeal:(UIViewController *)vc {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Error posting the deal"
+                                                                   message:@"An occur occurred. Please try again."
+                                                            preferredStyle:(UIAlertControllerStyleAlert)];
+    UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:@"Cancel"
+                                                            style:UIAlertActionStyleCancel
+                                                          handler:nil];
+    [alert addAction:cancelAction];
+    [vc presentViewController:alert animated:YES completion:nil];
+}
+
 @end

--- a/WiseBuy/View Controllers/ComposeViewController.m
+++ b/WiseBuy/View Controllers/ComposeViewController.m
@@ -7,6 +7,7 @@
 
 #import "ComposeViewController.h"
 #import "Parse/Parse.h"
+#import "AlertManager.h"
 
 @interface ComposeViewController () <UITextViewDelegate>
 @property (weak, nonatomic) IBOutlet UITextField *itemName;
@@ -38,8 +39,8 @@
     
     [post saveInBackgroundWithBlock:^(BOOL succeeded, NSError * _Nullable error) {
         if (!succeeded) {
+            [AlertManager cannotPostDeal:self];
             NSLog(@"%@", error.description);
-            // TODO: Send an alert to user saying there's an error
         } else {
             [self dismissViewControllerAnimated:true completion:nil];
         }


### PR DESCRIPTION
## Description

Display an alert to the user when the post could not be saved successfully

## Milestones
This is part of improving the user experience

## Test Plan
1. Run the app
2. Go to the `Feed` tab
3. Click the `Post` button
4. Try disconnecting with the Parse database and click `Compose` then the alert message will pop up