### PR TITLE
Fix the image bug in the `ProfileViewController`

### DIFF
--- a/WiseBuy/APIs/APIHelper.m
+++ b/WiseBuy/APIs/APIHelper.m
@@ -9,20 +9,29 @@
 #import "DatabaseManager.h"
 #import "Parse/Parse.h"
 
+static NSString *const kName = @"name";
+static NSString *const kDescription = @"description";
+static NSString *const kBarcode = @"barcode";
+static NSString *const kImage = @"image";
+static NSString *const kSellerNmae = @"sellerName";
+static NSString *const kPrice = @"price";
+static NSString *const kLink = @"link";
+static NSString *const kItem = @"item";
+
 @implementation APIHelper
 
 + (Item *)createItem: (NSString *)name description:(NSString *) description barcode:(NSString *) barcode imageUrl:(NSString *) imageUrl {
     Item *newItem = [Item new];
-    newItem[@"name"] = name;
-    newItem[@"description"] = description;
-    newItem[@"barcode"] = barcode;
+    newItem[kName] = name;
+    newItem[kDescription] = description;
+    newItem[kBarcode] = barcode;
     
     NSURL *url = [NSURL URLWithString:imageUrl];
     NSData *imageData = [NSData dataWithContentsOfURL:url];
     UIImage *img = [[UIImage alloc] initWithData:imageData];
     
     if (img) {
-        newItem[@"image"] = [DatabaseManager getPFFileFromImage:img];
+        newItem[kImage] = [DatabaseManager getPFFileFromImage:img];
     }
     if (![DatabaseManager checkIfItemAlreadyExist:barcode]) {
         [newItem saveInBackground];
@@ -33,20 +42,20 @@
 
 + (void)createDeal: (Item *)item sellerName:(NSString *) sellerName price:(NSString *) price link:(NSString *) link {    Deal *newDeal = [Deal new];
     
-    newDeal[@"item"] = item;
-    newDeal[@"sellerName"] = sellerName;
+    newDeal[kItem] = item;
+    newDeal[kSellerNmae] = sellerName;
     
     if ([price isKindOfClass:[NSString class]]) {
         NSNumberFormatter *f = [NSNumberFormatter new];
         f.numberStyle = NSNumberFormatterDecimalStyle;
         NSNumber *priceNumber = [f numberFromString:price];
         
-        newDeal[@"price"] = priceNumber;
+        newDeal[kPrice] = priceNumber;
     }
     else {
-        newDeal[@"price"] = price;
+        newDeal[kPrice] = price;
     }
-    newDeal[@"link"] = link;
+    newDeal[kLink] = link;
     [newDeal saveInBackground];
 }
 

--- a/WiseBuy/APIs/EbayAPI.m
+++ b/WiseBuy/APIs/EbayAPI.m
@@ -9,7 +9,8 @@
 
 static NSString *const kFirstHalfBaseURL = @"https://svcs.ebay.com/services/search/FindingService/v1?OPERATION-NAME=findItemsByProduct&SERVICE-VERSION=1.0.0&SECURITY-APPNAME=";
 static NSString *const kSecondHalfBaseURL = @"&RESPONSE-DATA-FORMAT=JSON&REST-PAYLOAD&paginationInput.entriesPerPage=2&productId.@type=ReferenceID&productId=";
-static NSString *const sellerName = @"Ebay";
+static NSString *const kSellerName = @"Ebay";
+static NSString *const kAppSecurityName = @"appSecurityName";
 
 @implementation EbayAPI
 
@@ -17,10 +18,10 @@ static NSString *const sellerName = @"Ebay";
     
     NSString *const path = [[NSBundle mainBundle] pathForResource: @"Keys" ofType: @"plist"];
     NSDictionary *const dict = [NSDictionary dictionaryWithContentsOfFile: path];
-    NSString *securityName = [dict objectForKey: @"appSecurityName"];
+    NSString *securityName = [dict objectForKey: kAppSecurityName];
     
-    if ([[NSUserDefaults standardUserDefaults] stringForKey:@"appSecurityName"]) {
-        securityName = [[NSUserDefaults standardUserDefaults] stringForKey:@"appSecurityName"];
+    if ([[NSUserDefaults standardUserDefaults] stringForKey:kAppSecurityName]) {
+        securityName = [[NSUserDefaults standardUserDefaults] stringForKey:kAppSecurityName];
     }
     
     NSString *const appSecurityName = securityName;
@@ -47,7 +48,7 @@ static NSString *const sellerName = @"Ebay";
                 NSString *const price = offer[@"sellingStatus"][0][@"convertedCurrentPrice"][0][@"__value__"];
                 NSString *const link = offer[@"viewItemURL"][0];
                 
-                [APIHelper createDeal:newItem sellerName:sellerName price:price link:link];
+                [APIHelper createDeal:newItem sellerName:kSellerName price:price link:link];
             }
         }
     }

--- a/WiseBuy/APIs/SearchUPCAPI.m
+++ b/WiseBuy/APIs/SearchUPCAPI.m
@@ -9,6 +9,8 @@
 
 static NSString *const kUpcQuery = @"&upc=";
 static NSString *const kBaseURL = @"https://www.searchupc.com/handlers/upcsearch.ashx?request_type=3&access_token=";
+static NSString *const kAccessToken = @"access_Token";
+static NSString *const kSearchUPCUserKey = @"searchUPC_userKey";
 
 @implementation SearchUPCAPI
 
@@ -16,19 +18,19 @@ static NSString *const kBaseURL = @"https://www.searchupc.com/handlers/upcsearch
     
     NSString *const path = [[NSBundle mainBundle] pathForResource: @"Keys" ofType: @"plist"];
     NSDictionary *const dict = [NSDictionary dictionaryWithContentsOfFile: path];
-    NSString *accessToken = [dict objectForKey: @"access_Token"];
+    NSString *accessToken = [dict objectForKey:kAccessToken];
     NSString *const accessTokenStr = accessToken;
     
-    if ([[NSUserDefaults standardUserDefaults] stringForKey:@"access_Token"]) {
-        accessToken = [[NSUserDefaults standardUserDefaults] stringForKey:@"access_Token"];
+    if ([[NSUserDefaults standardUserDefaults] stringForKey:kAccessToken]) {
+        accessToken = [[NSUserDefaults standardUserDefaults] stringForKey:kAccessToken];
     }
     
     NSString *fullURL = [NSString stringWithFormat:@"%@%@%@%@", kBaseURL, accessTokenStr, kUpcQuery, barcode];
     
-    NSString *userKey = [dict objectForKey: @"searchUPC_userKey"];
+    NSString *userKey = [dict objectForKey: kSearchUPCUserKey];
     
-    if ([[NSUserDefaults standardUserDefaults] stringForKey:@"searchUPC_userKey"]) {
-        userKey = [[NSUserDefaults standardUserDefaults] stringForKey:@"searchUPC_userKey"];
+    if ([[NSUserDefaults standardUserDefaults] stringForKey:kSearchUPCUserKey]) {
+        userKey = [[NSUserDefaults standardUserDefaults] stringForKey:kSearchUPCUserKey];
     }
     NSDictionary *headers = [[NSDictionary alloc] init];
     if (userKey) {

--- a/WiseBuy/APIs/UPCDatabaseAPI.m
+++ b/WiseBuy/APIs/UPCDatabaseAPI.m
@@ -8,6 +8,7 @@
 #import "UPCDatabaseAPI.h"
 
 static NSString *const kBaseURL = @"https://api.upcitemdb.com/prod/v1/lookup?upc=";
+static NSString *const kSearchUPCUserKey = @"upcDatabase_userKey";
 
 @implementation UPCDatabaseAPI
 
@@ -17,10 +18,10 @@ static NSString *const kBaseURL = @"https://api.upcitemdb.com/prod/v1/lookup?upc
     
     NSString *const path = [[NSBundle mainBundle] pathForResource: @"Keys" ofType: @"plist"];
     NSDictionary *const dict = [NSDictionary dictionaryWithContentsOfFile: path];
-    NSString *userKey = [dict objectForKey: @"searchUPC_userKey"];
+    NSString *userKey = [dict objectForKey: kSearchUPCUserKey];
     
-    if ([[NSUserDefaults standardUserDefaults] stringForKey:@"searchUPC_userKey"]) {
-        userKey = [[NSUserDefaults standardUserDefaults] stringForKey:@"searchUPC_userKey"];
+    if ([[NSUserDefaults standardUserDefaults] stringForKey:kSearchUPCUserKey]) {
+        userKey = [[NSUserDefaults standardUserDefaults] stringForKey:kSearchUPCUserKey];
     }
     NSDictionary *headers = [[NSDictionary alloc] init];
     if (userKey) {

--- a/WiseBuy/Managers/DatabaseManager.h
+++ b/WiseBuy/Managers/DatabaseManager.h
@@ -9,6 +9,8 @@
 #import "User.h"
 #import "Parse/Parse.h"
 #import "AppDeal.h"
+#import "Deal.h"
+#import "Item.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -19,15 +21,15 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)logoutUser:(UIViewController *)vc;
 + (void)getCurrentUser:(void(^)(User *user))completion;
 
-+ (void)fetchItem:(NSString *)barcode viewController:(UIViewController *)vc withCompletion:(void(^)(NSArray *deals,NSError *error))completion;
-+ (void)fetchRecentItems:(void(^)(NSArray *items,NSError *error))completion;
++ (void)fetchItem:(NSString *)barcode viewController:(UIViewController *)vc withCompletion:(void(^)(NSArray<Deal *> *deals,NSError *error))completion;
++ (void)fetchRecentItems:(void(^)(NSArray<Item *> *items,NSError *error))completion;
 
 + (PFFileObject *)getPFFileFromImage: (UIImage * _Nullable)image;
 + (BOOL)checkIfItemAlreadyExist:(NSString *)barcode;
 + (void)saveDeal:(AppDeal *)appDeal withCompletion:(void(^)(NSError *error))completion;
 + (void)unsaveDeal:(AppDeal *)appDeal withCompletion:(void(^)(NSError *error))completion;
-+ (void)fetchAllDeals:(void(^)(NSArray *deals ,NSError *error))completion;
-+ (void)fetchSavedDeals:(void(^)(NSArray *deals, NSError *error))completion;
++ (void)fetchAllDeals:(void(^)(NSArray<Deal *> *deals ,NSError *error))completion;
++ (void)fetchSavedDeals:(void(^)(NSArray<Deal *> *deals, NSError *error))completion;
 + (void)isCurrentDealSaved:(NSString *)identifier withCompletion:(void(^)(_Bool hasDeal, NSError *error))completion;
 @end
 

--- a/WiseBuy/Models/AppItem.h
+++ b/WiseBuy/Models/AppItem.h
@@ -6,6 +6,7 @@
 //
 
 #import <Foundation/Foundation.h>
+@import Parse;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -14,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) NSString *name;
 @property (nonatomic, strong) NSString *information;
 @property (nonatomic, strong) NSString *barcode;
-@property (nonatomic, strong) NSData *image;
+@property (nonatomic, strong) PFFileObject *image;
 @property (nonatomic, strong) NSString *identifier;
 
 @end

--- a/WiseBuy/View Controllers/DetailsViewController.m
+++ b/WiseBuy/View Controllers/DetailsViewController.m
@@ -32,7 +32,10 @@ static NSString *const kProgressHUDText = @"Loading...";
 - (void)viewDidLoad {
     [super viewDidLoad];
 
-    self.itemImageView.image = [UIImage imageWithData:self.deal.item.image];
+    NSURL *url = [NSURL URLWithString:self.deal.item.image.url];
+    NSData *data = [NSData dataWithContentsOfURL:url];
+    UIImage *image = [UIImage imageWithData:data];
+    self.itemImageView.image = image;
     self.itemName.text = self.deal.item.name;
     self.sellerName.text = self.deal.sellerName;
     self.priceLabel.text = [NSNumberFormatter localizedStringFromNumber:self.deal.price numberStyle:NSNumberFormatterCurrencyStyle];

--- a/WiseBuy/Views/DealCell.m
+++ b/WiseBuy/Views/DealCell.m
@@ -6,15 +6,16 @@
 //
 
 #import "DealCell.h"
-#import "Parse/Parse.h"
-#import "Item.h"
-#import "DatabaseManager.h"
 
 @implementation DealCell
 
 - (void)setDeal:(AppDeal *)deal {
     _deal = deal;
-    self.itemImage.image = [UIImage imageWithData:_deal.item.image];
+    
+    NSURL *url = [NSURL URLWithString:deal.item.image.url];
+    NSData *data = [NSData dataWithContentsOfURL:url];
+    UIImage *image = [UIImage imageWithData:data];
+    self.itemImage.image = image;
     self.itemName.text = _deal.item.name;
     self.sellerName.text = _deal.sellerName;
     self.price.text = [DealCell formattedPrice:_deal.price];

--- a/WiseBuy/Views/ItemCollectionViewCell.m
+++ b/WiseBuy/Views/ItemCollectionViewCell.m
@@ -11,7 +11,11 @@
 
 - (void)setItem:(AppItem *)item {
     _item = item;
-    self.itemImageView.image = [UIImage imageWithData:item.image];
+    NSURL *url = [NSURL URLWithString:item.image.url];
+    NSData *data = [NSData dataWithContentsOfURL:url];
+    UIImage *image = [UIImage imageWithData:data];
+    
+    self.itemImageView.image = image;
 }
 
 @end


### PR DESCRIPTION
## Description

Fix the item's image in the `ProfileViewController` by using `PFFileObject` instead of `NSData`

## Milestones

This is part of making sure all images are displayed without crashing

## Test Plan

<Images in the `DealsViewController`, `ProfileViewController` and `DetailsViewController` are now displayed without crashinig>

https://user-images.githubusercontent.com/63086003/182671896-6b338e63-a1b3-44e9-a18b-ee8e8a346c6d.MP4


