### PR TITLE
enable user to pull to refresh the deals feed in `RecommendationFeedViewController.m`

### DIFF
--- a/WiseBuy/View Controllers/RecommendationFeedViewController.m
+++ b/WiseBuy/View Controllers/RecommendationFeedViewController.m
@@ -17,6 +17,7 @@
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
 @property (nonatomic, strong) NSArray<Post *> *posts;
 @property (nonatomic, strong) NSURL *buyLink;
+@property (strong, nonatomic) UIRefreshControl *refreshControl;
 
 @end
 
@@ -42,6 +43,13 @@ static NSString *const kProgressHUDText = @"Loading Posts...";
     self.tableView.delegate = self;
     self.tableView.dataSource = self;
     self.tableView.rowHeight = UITableViewAutomaticDimension;
+    
+    self.refreshControl = [[UIRefreshControl alloc] init];
+    [self.refreshControl addTarget:self
+                         action:@selector(queryPosts)
+                         forControlEvents:UIControlEventValueChanged];
+    [self.tableView insertSubview:self.refreshControl atIndex:0];
+    
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -72,7 +80,9 @@ static NSString *const kProgressHUDText = @"Loading Posts...";
             self.posts = posts;
             [self.tableView reloadData];
             [progressHUD dismissAfterDelay:0.0 animated:YES];
+            [self.refreshControl endRefreshing];
             [ProgressHUDManager setLoadingState:NO viewController:self];
+
         } else {
             NSLog(@"%@", error.description);
         }


### PR DESCRIPTION
## Description

Allow users to pull to refresh the deals feed in `RecommendationFeedViewController.m` by adding an `UIRefreshControl`

## Milestones

This is part of improving user experience and allowing user to see deals posted by their friends after having just added a new friend to the friend list

## Test Plan

https://user-images.githubusercontent.com/63086003/183219943-6c492c47-1188-41b8-acb8-dd67b918d914.mov


